### PR TITLE
fix(openai): support gpt-5-nano parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ $openai = new OpenAI(
 ```
 
 Available OpenAI Models:
+- `MODEL_GPT_5_NANO`: GPT-5 Nano - Small GPT-5 variant optimized for low latency and cost-sensitive workloads
 - `MODEL_GPT_4_5_PREVIEW`: GPT-4.5 Preview - OpenAI's most advanced model with enhanced reasoning, broader knowledge, and improved instruction following
 - `MODEL_GPT_4_1`: GPT-4.1 - Advanced large language model with strong reasoning capabilities and improved context handling
 - `MODEL_GPT_4O`: GPT-4o - Multimodal model optimized for both text and image processing with faster response times

--- a/README.md
+++ b/README.md
@@ -144,14 +144,15 @@ use Utopia\Agents\Adapters\XAI;
 
 $xai = new XAI(
     apiKey: 'your-api-key',
-    model: XAI::MODEL_GROK_2_LATEST,
+    model: XAI::MODEL_GROK_3_MINI,
     maxTokens: 2048,
     temperature: 0.7
 );
 ```
 
 Available XAI Models:
-- `MODEL_GROK_2_LATEST`: Latest Grok model
+- `MODEL_GROK_3`: Latest Grok model
+- `MODEL_GROK_3_MINI`: Mini version of Grok model
 - `MODEL_GROK_2_IMAGE`: Latest Grok model with image support
 
 ### Managing Conversations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,12 @@ services:
       - ./phpunit.xml:/usr/src/code/phpunit.xml
     environment:
       - TESTING=true
-      - LLM_KEY_ANTHROPIC=${LLM_KEY_ANTHROPIC}
-      - LLM_KEY_OPENAI=${LLM_KEY_OPENAI}
-      - LLM_KEY_DEEPSEEK=${LLM_KEY_DEEPSEEK}
-      - LLM_KEY_XAI=${LLM_KEY_XAI}
-      - LLM_KEY_PERPLEXITY=${LLM_KEY_PERPLEXITY}
-      - LLM_KEY_GEMINI=${LLM_KEY_GEMINI}
+      - LLM_KEY_ANTHROPIC=${LLM_KEY_ANTHROPIC:-}
+      - LLM_KEY_OPENAI=${LLM_KEY_OPENAI:-}
+      - LLM_KEY_DEEPSEEK=${LLM_KEY_DEEPSEEK:-}
+      - LLM_KEY_XAI=${LLM_KEY_XAI:-}
+      - LLM_KEY_PERPLEXITY=${LLM_KEY_PERPLEXITY:-}
+      - LLM_KEY_GEMINI=${LLM_KEY_GEMINI:-}
     depends_on:
       - ollama
     networks:

--- a/src/Agents/Adapters/XAI.php
+++ b/src/Agents/Adapters/XAI.php
@@ -12,14 +12,19 @@ class XAI extends OpenAI
     protected const ENDPOINT = 'https://api.x.ai/v1/chat/completions';
 
     /**
-     * Grok 2 Latest - Latest Grok model
+     * Grok 3 - Latest Grok model
      */
-    public const MODEL_GROK_2_LATEST = 'grok-2-latest';
+    public const MODEL_GROK_3 = 'grok-3';
+
+    /**
+     * Grok 3 Mini - Mini version of grok 3
+     */
+    public const MODEL_GROK_3_MINI = 'grok-3-mini';
 
     /**
      * Grok 2 Image - Latest Grok model with image support
      */
-    public const MODEL_GROK_2_IMAGE = 'grok-2-image';
+    public const MODEL_GROK_2_IMAGE = 'grok-2-image-1212';
 
     /**
      * Create a new XAI adapter
@@ -35,7 +40,7 @@ class XAI extends OpenAI
      */
     public function __construct(
         string $apiKey,
-        string $model = self::MODEL_GROK_2_LATEST,
+        string $model = self::MODEL_GROK_3_MINI,
         int $maxTokens = 1024,
         float $temperature = 1.0,
         ?string $endpoint = null,
@@ -69,7 +74,8 @@ class XAI extends OpenAI
     public function getModels(): array
     {
         return [
-            self::MODEL_GROK_2_LATEST,
+            self::MODEL_GROK_3,
+            self::MODEL_GROK_3_MINI,
             self::MODEL_GROK_2_IMAGE,
         ];
     }

--- a/tests/Agents/Conversation/ConversationXAITest.php
+++ b/tests/Agents/Conversation/ConversationXAITest.php
@@ -17,7 +17,7 @@ class ConversationXAITest extends ConversationBase
 
         return new XAI(
             $apiKey,
-            XAI::MODEL_GROK_2_LATEST,
+            XAI::MODEL_GROK_3_MINI,
             1024,
             1.0
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the GPT-5 Nano model and new Grok 3 / Grok 3 Mini models (Grok 3 Mini is now the default XAI model).

* **Improvements**
  * Smarter temperature handling with one-time notice for overrides.
  * Improved token-limit selection per model.

* **Chores**
  * LLM environment variables now default to empty when unset.

* **Documentation**
  * README updated to list new models and adjusted license formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->