### PR TITLE
feat: add generic DiffCheck utility for repo diff analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM composer:2.0 AS composer
 
-ARG TESTING=false
-ENV TESTING=$TESTING
-
 WORKDIR /usr/local/src/
 COPY composer.lock /usr/local/src/
 COPY composer.json /usr/local/src/
@@ -23,6 +20,9 @@ WORKDIR /usr/src/code
 # Configure PHP
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && echo "memory_limit=256M" >> $PHP_INI_DIR/php.ini
+
+# Install required tooling
+RUN apk add --no-cache git
 
 # Copy composer dependencies
 COPY --from=composer /usr/local/src/vendor /usr/src/code/vendor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - ./tests:/usr/src/code/tests
       - ./phpunit.xml:/usr/src/code/phpunit.xml
     environment:
-      - TESTING=true
       - LLM_KEY_ANTHROPIC=${LLM_KEY_ANTHROPIC:-}
       - LLM_KEY_OPENAI=${LLM_KEY_OPENAI:-}
       - LLM_KEY_DEEPSEEK=${LLM_KEY_DEEPSEEK:-}

--- a/src/Agents/DiffCheck/DiffCheck.php
+++ b/src/Agents/DiffCheck/DiffCheck.php
@@ -1,0 +1,387 @@
+<?php
+
+namespace Utopia\Agents\DiffCheck;
+
+use Utopia\Agents\Adapter;
+use Utopia\Agents\Agent;
+use Utopia\Agents\Conversation;
+use Utopia\Agents\Messages\Text;
+use Utopia\Agents\Roles\User;
+
+class DiffCheck
+{
+    /**
+     * @param  Agent|Adapter  $runner Agent (preconfigured) or Adapter (wrapped into a new Agent)
+     * @param  Repository|string  $base Local path or remote URL
+     * @param  Repository|string  $target Local path or remote URL
+     * @param  string  $prompt User prompt. Supports placeholders: {{diff}}, {{base}}, {{target}}, {{diff_stats}}
+     * @param  Options|null  $options
+     * @return array{hasChanges: bool, response: string}
+     */
+    public function run(
+        Agent|Adapter $runner,
+        Repository|string $base,
+        Repository|string $target,
+        string $prompt,
+        ?Options $options = null
+    ): array {
+        $options ??= new Options();
+        $baseRepo = Repository::from($base);
+        $targetRepo = Repository::from($target);
+
+        $basePath = null;
+        $targetPath = null;
+
+        try {
+            $basePath = $this->materializeRepository($baseRepo, 'base');
+            $targetPath = $this->materializeRepository($targetRepo, 'target');
+
+            $this->applyExcludes($basePath, $options->getExcludePaths());
+            $this->applyExcludes($targetPath, $options->getExcludePaths());
+
+            $diffResult = $this->generateDiff($basePath, $targetPath, $options);
+
+            if (! $diffResult['hasChanges']) {
+                return [
+                    'hasChanges' => false,
+                    'response' => '',
+                ];
+            }
+
+            $finalPrompt = $this->buildPrompt(
+                prompt: $prompt,
+                diff: $diffResult['diff'],
+                base: $baseRepo->getSource(),
+                target: $targetRepo->getSource(),
+                stats: $diffResult['stats']
+            );
+
+            $agent = $this->resolveAgent($runner, $options);
+            $conversation = new Conversation($agent);
+            $response = $conversation
+                ->message(new User($options->getUserId()), new Text($finalPrompt))
+                ->send()
+                ->getContent();
+
+            return [
+                'hasChanges' => true,
+                'response' => $options->getTrimResponse() ? trim($response) : $response,
+            ];
+        } finally {
+            if ($basePath !== null) {
+                $this->deletePath($basePath);
+            }
+            if ($targetPath !== null) {
+                $this->deletePath($targetPath);
+            }
+        }
+    }
+
+    protected function resolveAgent(Agent|Adapter $runner, Options $options): Agent
+    {
+        if ($runner instanceof Agent) {
+            if ($options->getDescription() !== '') {
+                $runner->setDescription($options->getDescription());
+            }
+            if ($options->getInstructions() !== []) {
+                $runner->setInstructions($options->getInstructions());
+            }
+            if ($options->getSchema() !== null) {
+                $runner->setSchema($options->getSchema());
+            }
+
+            return $runner;
+        }
+
+        $agent = new Agent($runner);
+        if ($options->getDescription() !== '') {
+            $agent->setDescription($options->getDescription());
+        }
+        if ($options->getInstructions() !== []) {
+            $agent->setInstructions($options->getInstructions());
+        }
+        if ($options->getSchema() !== null) {
+            $agent->setSchema($options->getSchema());
+        }
+
+        return $agent;
+    }
+
+    protected function materializeRepository(Repository $repository, string $suffix): string
+    {
+        $path = $this->createTempDirectory($suffix);
+
+        if ($repository->isRemote()) {
+            $this->cloneRemoteRepository($repository, $path);
+
+            return $path;
+        }
+
+        $source = $repository->getSource();
+        $command = 'cp -R '.escapeshellarg($source.'/.').' '.escapeshellarg($path).' 2>&1';
+        $result = $this->runCommand($command);
+
+        if ($result['code'] !== 0) {
+            throw new \RuntimeException('Failed to copy local repository: '.implode("\n", $result['output']));
+        }
+
+        if ($repository->getRef() !== null) {
+            $checkout = $this->runCommand(
+                'git -C '.escapeshellarg($path).' checkout '.escapeshellarg($repository->getRef()).' 2>&1'
+            );
+            if ($checkout['code'] !== 0) {
+                throw new \RuntimeException('Failed to checkout ref "'.$repository->getRef().'": '.implode("\n", $checkout['output']));
+            }
+        }
+
+        return $path;
+    }
+
+    protected function cloneRemoteRepository(Repository $repository, string $destination): void
+    {
+        $ref = $repository->getRef();
+        if ($ref === null) {
+            $clone = $this->runCommand(
+                'git clone --depth 1 '.escapeshellarg($repository->getSource()).' '.escapeshellarg($destination).' 2>&1'
+            );
+
+            if ($clone['code'] !== 0) {
+                throw new \RuntimeException('Failed to clone repository: '.implode("\n", $clone['output']));
+            }
+
+            return;
+        }
+
+        $clone = $this->runCommand(
+            'git clone '.escapeshellarg($repository->getSource()).' '.escapeshellarg($destination).' 2>&1'
+        );
+        if ($clone['code'] !== 0) {
+            throw new \RuntimeException('Failed to clone repository: '.implode("\n", $clone['output']));
+        }
+
+        $checkout = $this->runCommand(
+            'git -C '.escapeshellarg($destination).' checkout '.escapeshellarg($ref).' 2>&1'
+        );
+        if ($checkout['code'] !== 0) {
+            throw new \RuntimeException('Failed to checkout ref "'.$ref.'": '.implode("\n", $checkout['output']));
+        }
+    }
+
+    /**
+     * @return array{
+     *     hasChanges: bool,
+     *     diff: string,
+     *     stats: string
+     * }
+     */
+    protected function generateDiff(string $basePath, string $targetPath, Options $options): array
+    {
+        $flags = [];
+        if ($options->getIgnoreAllSpace()) {
+            $flags[] = '--ignore-all-space';
+        }
+        if ($options->getIgnoreBlankLines()) {
+            $flags[] = '--ignore-blank-lines';
+        }
+
+        $command = 'git diff --quiet --no-index '
+            .implode(' ', $flags)
+            .' -- '
+            .escapeshellarg($basePath).' '
+            .escapeshellarg($targetPath)
+            .' 2>&1';
+
+        $result = $this->runCommand($command);
+
+        if (! in_array($result['code'], [0, 1], true)) {
+            throw new \RuntimeException('Failed to generate diff: '.implode("\n", $result['output']));
+        }
+
+        if ($result['code'] === 0) {
+            return [
+                'hasChanges' => false,
+                'diff' => '',
+                'stats' => '0 lines, 0 bytes',
+            ];
+        }
+
+        $maxLines = $options->getMaxDiffLines();
+        $captureLines = $maxLines + 1;
+        $outputResult = $this->runCommand(
+            '(git diff --no-index '.implode(' ', $flags).' -- '.escapeshellarg($basePath).' '.escapeshellarg($targetPath).') 2>&1'
+            .' | head -n '
+            .(string) $captureLines
+        );
+
+        $lines = $outputResult['output'];
+        $capturedLineCount = count($lines);
+        $truncated = $capturedLineCount > $maxLines;
+        if ($truncated) {
+            $lines = array_slice($lines, 0, $maxLines);
+        }
+
+        $diff = implode("\n", $lines);
+        if ($truncated) {
+            $diff .= "\n\n[Diff truncated to {$maxLines} lines.]";
+        }
+
+        return [
+            'hasChanges' => true,
+            'diff' => $diff,
+            'stats' => ($truncated ? '>='.$maxLines : (string) $capturedLineCount).' lines, '.strlen($diff).' bytes'.($truncated ? ', truncated' : ''),
+        ];
+    }
+
+    protected function buildPrompt(
+        string $prompt,
+        string $diff,
+        string $base,
+        string $target,
+        string $stats
+    ): string {
+        $replacements = [
+            '{{diff}}' => $diff,
+            '{{base}}' => $base,
+            '{{target}}' => $target,
+            '{{diff_stats}}' => $stats,
+        ];
+
+        $finalPrompt = strtr($prompt, $replacements);
+
+        if (! str_contains($prompt, '{{diff}}')) {
+            $finalPrompt .= "\n\nGit diff:\n```diff\n{$diff}\n```";
+        }
+
+        return $finalPrompt;
+    }
+
+    /**
+     * @param  array<int, string>  $patterns
+     */
+    protected function applyExcludes(string $root, array $patterns): void
+    {
+        if ($patterns === []) {
+            return;
+        }
+
+        $normalized = [];
+        foreach ($patterns as $pattern) {
+            $pattern = trim(str_replace('\\', '/', $pattern));
+            if ($pattern === '') {
+                continue;
+            }
+            $normalized[] = ltrim($pattern, '/');
+        }
+
+        if ($normalized === []) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        /** @var \SplFileInfo $item */
+        foreach ($iterator as $item) {
+            $path = $item->getPathname();
+            $relative = str_replace('\\', '/', substr($path, strlen($root) + 1));
+            if ($relative === '') {
+                continue;
+            }
+
+            foreach ($normalized as $pattern) {
+                if ($this->matchesGlob($relative, $pattern)) {
+                    if (is_dir($path)) {
+                        $this->deletePath($path);
+                    } else {
+                        @unlink($path);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    protected function matchesGlob(string $path, string $pattern): bool
+    {
+        $path = trim($path, '/');
+        $pattern = trim($pattern, '/');
+
+        if ($pattern === '') {
+            return false;
+        }
+
+        if (str_ends_with($pattern, '/**') && $path === substr($pattern, 0, -3)) {
+            return true;
+        }
+
+        $escaped = preg_quote($pattern, '/');
+        $escaped = str_replace('\*\*', '::DOUBLE_WILDCARD::', $escaped);
+        $escaped = str_replace('\*', '[^/]*', $escaped);
+        $escaped = str_replace('\?', '[^/]', $escaped);
+        $escaped = str_replace('::DOUBLE_WILDCARD::', '.*', $escaped);
+
+        return (bool) preg_match('/^'.$escaped.'$/', $path);
+    }
+
+    protected function createTempDirectory(string $suffix): string
+    {
+        $path = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR)
+            .DIRECTORY_SEPARATOR
+            .'utopia-diff-check-'
+            .$suffix
+            .'-'
+            .bin2hex(random_bytes(8));
+
+        if (! mkdir($path, 0777, true) && ! is_dir($path)) {
+            throw new \RuntimeException('Failed to create temp directory: '.$path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array{code: int, output: array<int, string>}
+     */
+    protected function runCommand(string $command): array
+    {
+        $output = [];
+        $code = 0;
+        exec($command, $output, $code);
+
+        return [
+            'code' => $code,
+            'output' => $output,
+        ];
+    }
+
+    protected function deletePath(string $path): void
+    {
+        if (! file_exists($path)) {
+            return;
+        }
+
+        if (is_file($path) || is_link($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        /** @var \SplFileInfo $item */
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+
+        @rmdir($path);
+    }
+}

--- a/src/Agents/DiffCheck/Options.php
+++ b/src/Agents/DiffCheck/Options.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Utopia\Agents\DiffCheck;
+
+use Utopia\Agents\Schema;
+
+class Options
+{
+    protected int $maxDiffLines = 500;
+
+    /**
+     * @var array<int, string>
+     */
+    protected array $excludePaths = [];
+
+    protected bool $ignoreAllSpace = true;
+
+    protected bool $ignoreBlankLines = true;
+
+    protected ?Schema $schema = null;
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $instructions = [];
+
+    protected string $description = '';
+
+    protected string $userId = 'diff-check-user';
+
+    protected bool $trimResponse = true;
+
+    public function getMaxDiffLines(): int
+    {
+        return $this->maxDiffLines;
+    }
+
+    public function setMaxDiffLines(int $maxDiffLines): self
+    {
+        if ($maxDiffLines < 1) {
+            throw new \InvalidArgumentException('maxDiffLines must be greater than 0');
+        }
+
+        $this->maxDiffLines = $maxDiffLines;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getExcludePaths(): array
+    {
+        return $this->excludePaths;
+    }
+
+    /**
+     * @param  array<int, string>  $excludePaths
+     */
+    public function setExcludePaths(array $excludePaths): self
+    {
+        $this->excludePaths = array_values(array_filter(array_map('trim', $excludePaths), function ($path) {
+            return $path !== '';
+        }));
+
+        return $this;
+    }
+
+    public function addExcludePath(string $excludePath): self
+    {
+        $excludePath = trim($excludePath);
+        if ($excludePath !== '') {
+            $this->excludePaths[] = $excludePath;
+        }
+
+        return $this;
+    }
+
+    public function getIgnoreAllSpace(): bool
+    {
+        return $this->ignoreAllSpace;
+    }
+
+    public function setIgnoreAllSpace(bool $ignoreAllSpace): self
+    {
+        $this->ignoreAllSpace = $ignoreAllSpace;
+
+        return $this;
+    }
+
+    public function getIgnoreBlankLines(): bool
+    {
+        return $this->ignoreBlankLines;
+    }
+
+    public function setIgnoreBlankLines(bool $ignoreBlankLines): self
+    {
+        $this->ignoreBlankLines = $ignoreBlankLines;
+
+        return $this;
+    }
+
+    public function getSchema(): ?Schema
+    {
+        return $this->schema;
+    }
+
+    public function setSchema(?Schema $schema): self
+    {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getInstructions(): array
+    {
+        return $this->instructions;
+    }
+
+    /**
+     * @param  array<string, string>  $instructions
+     */
+    public function setInstructions(array $instructions): self
+    {
+        $this->instructions = $instructions;
+
+        return $this;
+    }
+
+    public function addInstruction(string $name, string $content): self
+    {
+        $this->instructions[$name] = $content;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getUserId(): string
+    {
+        return $this->userId;
+    }
+
+    public function setUserId(string $userId): self
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('userId must not be empty');
+        }
+
+        $this->userId = $userId;
+
+        return $this;
+    }
+
+    public function getTrimResponse(): bool
+    {
+        return $this->trimResponse;
+    }
+
+    public function setTrimResponse(bool $trimResponse): self
+    {
+        $this->trimResponse = $trimResponse;
+
+        return $this;
+    }
+}

--- a/src/Agents/DiffCheck/Repository.php
+++ b/src/Agents/DiffCheck/Repository.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Utopia\Agents\DiffCheck;
+
+class Repository
+{
+    protected string $source;
+
+    protected bool $remote;
+
+    protected ?string $ref;
+
+    public function __construct(string $source, bool $remote = false, ?string $ref = null)
+    {
+        $source = trim($source);
+        if ($source === '') {
+            throw new \InvalidArgumentException('Repository source must not be empty');
+        }
+
+        $this->source = $source;
+        $this->remote = $remote;
+        $this->ref = $ref;
+    }
+
+    public static function local(string $path, ?string $ref = null): self
+    {
+        $resolved = realpath($path);
+        if ($resolved === false || ! is_dir($resolved)) {
+            throw new \InvalidArgumentException('Local repository path does not exist: '.$path);
+        }
+
+        return new self($resolved, false, $ref);
+    }
+
+    public static function remote(string $url, ?string $ref = null): self
+    {
+        return new self($url, true, $ref);
+    }
+
+    public static function from(string|self $repository): self
+    {
+        if ($repository instanceof self) {
+            return $repository;
+        }
+
+        $value = trim($repository);
+        if ($value === '') {
+            throw new \InvalidArgumentException('Repository source must not be empty');
+        }
+
+        if (file_exists($value)) {
+            return self::local($value);
+        }
+
+        if (self::looksLikeRemote($value)) {
+            return self::remote($value);
+        }
+
+        throw new \InvalidArgumentException('Repository source is not a valid local path or remote URL: '.$value);
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function isRemote(): bool
+    {
+        return $this->remote;
+    }
+
+    public function getRef(): ?string
+    {
+        return $this->ref;
+    }
+
+    protected static function looksLikeRemote(string $value): bool
+    {
+        if (preg_match('/^(https?:\/\/|ssh:\/\/|git:\/\/|git@|file:\/\/)/', $value) === 1) {
+            return true;
+        }
+
+        // git@github.com:org/repo.git
+        if (preg_match('/^[^@\s]+@[^:\s]+:.+$/', $value) === 1) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/Agents/DiffCheck/DiffCheckOpenAITest.php
+++ b/tests/Agents/DiffCheck/DiffCheckOpenAITest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Utopia\Agents\DiffCheck;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Agents\Adapters\OpenAI;
+use Utopia\Agents\DiffCheck\DiffCheck;
+use Utopia\Agents\DiffCheck\Options;
+use Utopia\Agents\Schema;
+use Utopia\Agents\Schema\SchemaObject;
+
+class DiffCheckOpenAITest extends TestCase
+{
+    private string $tempRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tempRoot = sys_get_temp_dir().'/utopia-diff-check-openai-tests-'.bin2hex(random_bytes(8));
+        mkdir($this->tempRoot, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->tempRoot) && is_dir($this->tempRoot)) {
+            $this->deletePath($this->tempRoot);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @group integration
+     */
+    public function testRunWithOpenAIGpt5Nano(): void
+    {
+        $apiKey = getenv('LLM_KEY_OPENAI');
+        if ($apiKey === false || trim($apiKey) === '') {
+            $this->markTestSkipped('LLM_KEY_OPENAI environment variable is not set');
+        }
+
+        $base = $this->createFixtureDirectory('base', [
+            'README.md' => "Hello\n",
+            '.github/workflows/build.yml' => "name: build\n",
+        ]);
+        $target = $this->createFixtureDirectory('target', [
+            'README.md' => "Hello world\n",
+            '.github/workflows/build.yml' => "name: build-updated\n",
+        ]);
+
+        $adapter = new OpenAI(
+            apiKey: $apiKey,
+            model: OpenAI::MODEL_GPT_5_NANO,
+            maxTokens: 1024,
+            temperature: 1.0
+        );
+
+        $schemaObject = new SchemaObject();
+        $schemaObject->addProperty('summary', [
+            'type' => SchemaObject::TYPE_STRING,
+            'description' => 'One concise sentence about user-facing diff changes.',
+        ]);
+        $schema = new Schema(
+            name: 'diff_check_openai_test',
+            description: 'Return concise summary for changed SDK diff',
+            object: $schemaObject,
+            required: $schemaObject->getNames()
+        );
+
+        $options = (new Options())
+            ->setSchema($schema)
+            ->setExcludePaths(['.github'])
+            ->setDescription('You analyze code diffs and return concise structured output.');
+
+        $result = (new DiffCheck())->run(
+            runner: $adapter,
+            base: $base,
+            target: $target,
+            prompt: "Summarize the user-facing change from this diff.\n\n{{diff}}",
+            options: $options
+        );
+
+        $this->assertTrue($result['hasChanges']);
+        $this->assertIsString($result['response']);
+        $this->assertNotSame('', trim($result['response']));
+
+        $decoded = json_decode($result['response'], true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('summary', $decoded);
+        $this->assertIsString($decoded['summary']);
+        $this->assertNotSame('', trim($decoded['summary']));
+    }
+
+    /**
+     * @param  array<string, string>  $files
+     */
+    private function createFixtureDirectory(string $name, array $files): string
+    {
+        $root = $this->tempRoot.'/'.$name;
+        mkdir($root, 0777, true);
+
+        foreach ($files as $relative => $content) {
+            $path = $root.'/'.$relative;
+            $dir = dirname($path);
+            if (! is_dir($dir)) {
+                mkdir($dir, 0777, true);
+            }
+            file_put_contents($path, $content);
+        }
+
+        return $root;
+    }
+
+    private function deletePath(string $path): void
+    {
+        if (! file_exists($path)) {
+            return;
+        }
+
+        if (is_file($path) || is_link($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        /** @var \SplFileInfo $item */
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+
+        @rmdir($path);
+    }
+}

--- a/tests/Agents/DiffCheck/DiffCheckTest.php
+++ b/tests/Agents/DiffCheck/DiffCheckTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Tests\Utopia\Agents\DiffCheck;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Agents\Adapter;
+use Utopia\Agents\Agent;
+use Utopia\Agents\DiffCheck\DiffCheck;
+use Utopia\Agents\DiffCheck\Options;
+use Utopia\Agents\Message;
+use Utopia\Agents\Messages\Text;
+
+class DiffCheckTest extends TestCase
+{
+    private string $tempRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempRoot = sys_get_temp_dir().'/utopia-diff-check-tests-'.bin2hex(random_bytes(8));
+        mkdir($this->tempRoot, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->tempRoot) && is_dir($this->tempRoot)) {
+            $this->deletePath($this->tempRoot);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testRunSkipsAiWhenThereIsNoDiff(): void
+    {
+        $base = $this->createFixtureDirectory('base-no-diff', [
+            'README.md' => "Hello\n",
+        ]);
+        $target = $this->createFixtureDirectory('target-no-diff', [
+            'README.md' => "Hello\n",
+        ]);
+
+        $adapter = new FakeAdapter('should-not-be-called');
+        $result = (new DiffCheck())->run(
+            runner: $adapter,
+            base: $base,
+            target: $target,
+            prompt: 'Analyze this diff: {{diff}}',
+            options: new Options()
+        );
+
+        $this->assertFalse($result['hasChanges']);
+        $this->assertSame('', $result['response']);
+        $this->assertSame(0, $adapter->sendCalls);
+    }
+
+    public function testRunReturnsResponseWhenDiffExists(): void
+    {
+        $base = $this->createFixtureDirectory('base-diff', [
+            'README.md' => "Hello\n",
+        ]);
+        $target = $this->createFixtureDirectory('target-diff', [
+            'README.md' => "Hello world\n",
+        ]);
+
+        $adapter = new FakeAdapter('{"version":"1.2.3"}');
+        $result = (new DiffCheck())->run(
+            runner: $adapter,
+            base: $base,
+            target: $target,
+            prompt: 'Please inspect:\n{{diff}}',
+            options: new Options()
+        );
+
+        $this->assertTrue($result['hasChanges']);
+        $this->assertSame('{"version":"1.2.3"}', $result['response']);
+        $this->assertSame(1, $adapter->sendCalls);
+        $this->assertNotNull($adapter->lastUserPrompt);
+        $this->assertStringContainsString('Hello world', $adapter->lastUserPrompt ?? '');
+    }
+
+    public function testRunSupportsAgentRunner(): void
+    {
+        $base = $this->createFixtureDirectory('base-agent', [
+            'a.txt' => "one\n",
+        ]);
+        $target = $this->createFixtureDirectory('target-agent', [
+            'a.txt' => "two\n",
+        ]);
+
+        $adapter = new FakeAdapter('agent-runner-ok');
+        $agent = new Agent($adapter);
+        $agent->setInstructions([
+            'description' => 'Return the raw result',
+        ]);
+
+        $result = (new DiffCheck())->run(
+            runner: $agent,
+            base: $base,
+            target: $target,
+            prompt: 'Analyze: {{diff}}',
+            options: new Options()
+        );
+
+        $this->assertTrue($result['hasChanges']);
+        $this->assertSame('agent-runner-ok', $result['response']);
+        $this->assertSame(1, $adapter->sendCalls);
+    }
+
+    public function testRunTruncatesDiffByLineCount(): void
+    {
+        $baseLines = [];
+        $targetLines = [];
+        for ($i = 1; $i <= 25; $i++) {
+            $baseLines[] = 'old line '.$i;
+            $targetLines[] = 'new line '.$i;
+        }
+
+        $base = $this->createFixtureDirectory('base-truncate', [
+            'long.txt' => implode("\n", $baseLines)."\n",
+        ]);
+        $target = $this->createFixtureDirectory('target-truncate', [
+            'long.txt' => implode("\n", $targetLines)."\n",
+        ]);
+
+        $adapter = new FakeAdapter('ok');
+        $options = (new Options())
+            ->setMaxDiffLines(8);
+
+        $result = (new DiffCheck())->run(
+            runner: $adapter,
+            base: $base,
+            target: $target,
+            prompt: 'Analyze the diff\n{{diff}}',
+            options: $options
+        );
+
+        $this->assertTrue($result['hasChanges']);
+        $this->assertSame('ok', $result['response']);
+        $this->assertNotNull($adapter->lastUserPrompt);
+        $this->assertStringContainsString('[Diff truncated to 8 lines.]', $adapter->lastUserPrompt ?? '');
+    }
+
+    public function testRunCanExcludePathsFromDiff(): void
+    {
+        $base = $this->createFixtureDirectory('base-exclude', [
+            '.github/workflows/build.yml' => "name: build\n",
+            'src/main.txt' => "same\n",
+        ]);
+        $target = $this->createFixtureDirectory('target-exclude', [
+            '.github/workflows/build.yml' => "name: build-updated\n",
+            'src/main.txt' => "same\n",
+        ]);
+
+        $adapter = new FakeAdapter('should-not-run');
+        $options = (new Options())
+            ->setExcludePaths(['.github']);
+
+        $result = (new DiffCheck())->run(
+            runner: $adapter,
+            base: $base,
+            target: $target,
+            prompt: 'Analyze {{diff}}',
+            options: $options
+        );
+
+        $this->assertFalse($result['hasChanges']);
+        $this->assertSame('', $result['response']);
+        $this->assertSame(0, $adapter->sendCalls);
+    }
+
+    /**
+     * @param  array<string, string>  $files
+     */
+    private function createFixtureDirectory(string $name, array $files): string
+    {
+        $root = $this->tempRoot.'/'.$name;
+        mkdir($root, 0777, true);
+
+        foreach ($files as $relative => $content) {
+            $path = $root.'/'.$relative;
+            $dir = dirname($path);
+            if (! is_dir($dir)) {
+                mkdir($dir, 0777, true);
+            }
+            file_put_contents($path, $content);
+        }
+
+        return $root;
+    }
+
+    private function deletePath(string $path): void
+    {
+        if (! file_exists($path)) {
+            return;
+        }
+
+        if (is_file($path) || is_link($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        /** @var \SplFileInfo $item */
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+
+        @rmdir($path);
+    }
+}
+
+class FakeAdapter extends Adapter
+{
+    public int $sendCalls = 0;
+
+    public ?string $lastUserPrompt = null;
+
+    private string $response;
+
+    public function __construct(string $response)
+    {
+        $this->response = $response;
+    }
+
+    public function getName(): string
+    {
+        return 'fake';
+    }
+
+    /**
+     * @param  array<Message>  $messages
+     */
+    public function send(array $messages, ?callable $listener = null): Message
+    {
+        $this->sendCalls++;
+        $last = end($messages);
+        if ($last instanceof Message) {
+            $this->lastUserPrompt = $last->getContent();
+        }
+
+        return new Text($this->response);
+    }
+
+    public function getModels(): array
+    {
+        return ['fake-model'];
+    }
+
+    public function getModel(): string
+    {
+        return 'fake-model';
+    }
+
+    public function setModel(string $model): self
+    {
+        return $this;
+    }
+
+    public function isSchemaSupported(): bool
+    {
+        return true;
+    }
+
+    public function getSupportForEmbeddings(): bool
+    {
+        return false;
+    }
+
+    public function embed(string $text): array
+    {
+        throw new \Exception('Embeddings not supported by fake adapter');
+    }
+
+    public function getEmbeddingDimension(): int
+    {
+        return 0;
+    }
+
+    protected function formatErrorMessage($json): string
+    {
+        return 'fake error';
+    }
+}


### PR DESCRIPTION
## Summary
- add a generic DiffCheck utility that compares two repositories (local path or remote git URL)
- support Agent|Adapter runners, optional schema/instructions, path excludes, and line-based diff truncation
- skip AI call entirely when there are no diff changes and return array{hasChanges: bool, response: string}
- add unit tests for no-diff skip, diff path, agent runner support, truncation, and excludes
- add OpenAI integration test using gpt-5-nano gated by LLM_KEY_OPENAI

## Validation
- vendor/bin/phpunit --configuration phpunit.xml tests/Agents/DiffCheck/DiffCheckTest.php
- vendor/bin/phpunit --configuration phpunit.xml tests/Agents/DiffCheck/DiffCheckOpenAITest.php (skips without LLM_KEY_OPENAI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DiffCheck functionality to analyze differences between repositories and generate AI-driven insights.
  * Support for both local and remote repository sources.
  * Configurable diff analysis options including line limits, path exclusions, and whitespace handling.

* **Tests**
  * Added comprehensive test coverage for DiffCheck functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->