### PR TITLE
feat: update utopia-php/fetch to ^1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "utopia-php/fetch": "0.5.*"
+        "utopia-php/fetch": "^1.1.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ecc449b1e13964d6148a820f8388ddd7",
+    "content-hash": "a7d3a9faec5057e202fd07e780294b21",
     "packages": [
         {
             "name": "utopia-php/fetch",
-            "version": "0.5.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/fetch.git",
-                "reference": "a96a010e1c273f3888765449687baf58cbc61fcd"
+                "reference": "d5e8d8baafe6715eb1a3fb11c956d50cbaebd428"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/fetch/zipball/a96a010e1c273f3888765449687baf58cbc61fcd",
-                "reference": "a96a010e1c273f3888765449687baf58cbc61fcd",
+                "url": "https://api.github.com/repos/utopia-php/fetch/zipball/d5e8d8baafe6715eb1a3fb11c956d50cbaebd428",
+                "reference": "d5e8d8baafe6715eb1a3fb11c956d50cbaebd428",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,8 @@
             "require-dev": {
                 "laravel/pint": "^1.5.0",
                 "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^9.5",
+                "swoole/ide-helper": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -41,9 +42,9 @@
             "description": "A simple library that provides an interface for making HTTP Requests.",
             "support": {
                 "issues": "https://github.com/utopia-php/fetch/issues",
-                "source": "https://github.com/utopia-php/fetch/tree/0.5.1"
+                "source": "https://github.com/utopia-php/fetch/tree/1.1.0"
             },
-            "time": "2025-12-18T16:25:10+00:00"
+            "time": "2026-03-30T04:13:01+00:00"
         }
     ],
     "packages-dev": [
@@ -1864,5 +1865,5 @@
         "php": ">=8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary
Update `utopia-php/fetch` dependency from `0.5.*` to `^1.1.0`.

## What Changed
- Updated `composer.json` to require `utopia-php/fetch` `^1.1.0`
- No code changes needed — the agents library already uses milliseconds for timeouts (default 90000ms = 90s), which is the unit expected by fetch 1.1.0

## Verification
- `composer update` successfully resolves and installs fetch 1.1.0
- `vendor/bin/phpstan analyse --level max src tests` passes with no errors
- `composer lint` passes
- Unit tests pass (integration tests require external API keys which are not available in CI)

## Type of Change
- [x] Dependency update
